### PR TITLE
Update map generation to be more natural, turn off unnecessary settings

### DIFF
--- a/data-updates.lua
+++ b/data-updates.lua
@@ -2,6 +2,7 @@ local fun = require('functions/functions')
 require('prototypes/updates/pyhightech-updates')
 require('prototypes/updates/pyalienlife-updates')
 require('prototypes/updates/ddc-coal-updates')
+require('prototypes/updates/generator-updates')
 
 RECIPE("bio-reactor"):replace_ingredient('advanced-circuit','electronic-circuit')
 

--- a/data.lua
+++ b/data.lua
@@ -28,6 +28,8 @@ require("prototypes/recipes")
 --require("prototypes/overrides/angel-recipe-overrides")
 --require("prototypes/overrides/angel-tech-overrides")
 
+require("prototypes/generator")
+
 
 --formula to calulate steam consumption
 --flowrate (in units/s) * heat capacity (J/unit/C) * (T - 15 C) = wattage

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -76,3 +76,10 @@ alloying-mk02=Alloying 2
 
 [controls]
 recipe-selector=Recipe Selector
+
+[mod-setting-name]
+pyblock-ore-distance-richness=Enable distance based ore richness
+
+
+[mod-setting-description]
+pyblock-ore-distance-richness=Generated ores are more lucrative the further away from the starting area they spawn.

--- a/prototypes/generator.lua
+++ b/prototypes/generator.lua
@@ -1,0 +1,140 @@
+
+for _,v in pairs(data.raw.tile) do
+  v.autoplace = nil
+end
+
+-- Want player to collide with cliffs
+-- Want player to collide with water
+-- Don't want cliffs to collide with water
+-- Water tile's default collision mask includes player-layer and item-layer
+-- So use train-layer as a substitute player-layer
+data.raw.cliff['cliff'].collision_mask =
+  {"object-layer", "train-layer", "not-colliding-with-itself"}
+
+local octaves = -3
+local persistence = 0.2
+local waterline = 11.4
+local elevation_scale = 5
+
+local function scale_elevation(x)
+  return (x - waterline) * elevation_scale + waterline
+end
+-- low lying sand
+data.raw.tile['sand-1'].autoplace = {
+  peaks = {
+  { -- Around cliff islands
+    influence = 5,
+    elevation_optimal = 0.3 * elevation_scale + waterline,
+    elevation_range = 0.4 * elevation_scale,
+    elevation_max_range = 4.4 * elevation_scale
+  },
+  { -- Not in starting area
+    influence = -5,
+    starting_area_weight_optimal = 1,
+    starting_area_weight_range = 0,
+    starting_area_weight_max_range = 0
+  },
+  {
+    influence = 100, -- ... except for starting tile
+    min_influence = 0,
+    distance_optimal = 0,
+    distance_range = 0.1,
+    distance_max_range = 0.1
+  },
+  {
+    influence = -5
+  }
+}}
+
+-- highground sand
+data.raw.tile['sand-2'].autoplace = {
+  peaks = {
+  {
+    influence = 5,
+    min_influence = 0,
+    elevation_optimal = scale_elevation(15),
+    elevation_range = 5 * elevation_scale,
+    elevation_max_range = 5 * elevation_scale,
+    tier_from_start_optimal = 0.1,
+    tier_from_start_range = 0,
+    tier_from_start_max_range = 0,
+    tier_from_start_top_property_limit = 0.1
+  },
+  {
+    influence = 1,
+    max_influence = 0,
+    starting_area_weight_optimal = 1,
+    starting_area_weight_range = 0,
+    starting_area_weight_max_range = 0
+  },
+  {
+    influence = -100, -- not on starting tile
+    max_influence = 0,
+    distance_optimal = 0,
+    distance_range = 3,
+    distance_max_range = 3
+  },
+}}
+
+data.raw.tile['water'].autoplace = {
+  peaks = {
+  {
+    influence = 0.1, -- shallow water around cliff islands
+    min_influence = 0,
+    elevation_optimal = -4 * elevation_scale + waterline,
+    elevation_range = 3.5 * elevation_scale,
+    elevation_max_range = 3.5 * elevation_scale
+  },
+  {
+    influence = 5, -- around starting tile
+    min_influence = 0,
+    distance_optimal = 0,
+    distance_range = 5,
+    distance_max_range = 5
+  }
+}}
+
+data.raw.tile['deepwater'].autoplace = {
+  peaks = {
+  {
+    influence = 0.01
+  }
+}}
+
+local noise = require "noise"
+local tne = noise.to_noise_expression
+
+
+local function make_basis_noise_function(seed0,seed1,outscale0,inscale0)
+  outscale0 = outscale0 or 1
+  inscale0 = inscale0 or 1/outscale0
+  return function(x,y,inscale,outscale)
+    return tne{
+      type = "function-application",
+      function_name = "factorio-basis-noise",
+      arguments = {
+        x = tne(x),
+        y = tne(y),
+        seed0 = tne(seed0),
+        seed1 = tne(seed1),
+        input_scale = tne((inscale or 1) * inscale0),
+        output_scale = tne((outscale or 1) * outscale0)
+      }
+    }
+  end
+end
+
+data.raw['noise-expression']['cliffiness'].expression =
+  noise.define_noise_function(function(x, y, tile, map)
+    local t = noise.clamp(tile.tier - 0.2, 0, 1) -- No cliffs in starting area
+    return 100 * t
+  end)
+data.raw['noise-expression']['elevation'].expression =
+  noise.define_noise_function(function(x, y, tile, map)
+      x = x + 40000
+      y = y
+      local v = make_basis_noise_function(map.seed, 5, 6, 1/112)(x, y)
+      v = noise.max(v, 0)
+      v = (v * elevation_scale) - (waterline * (elevation_scale - 1)) -- Increase gradient for cliffs while leaving waterline unchanged
+      return v
+  end)

--- a/prototypes/updates/generator-updates.lua
+++ b/prototypes/updates/generator-updates.lua
@@ -1,0 +1,59 @@
+
+local ores = {
+	'stone',
+	'iron-ore',
+	'copper-ore',
+	'uranium-ore',
+	--'enemy-base',
+	'ore-aluminium',
+	'ore-chromium',
+	'ore-lead',
+	'ore-nickel',
+	'ore-quartz',
+	'ore-tin',
+	'ore-titanium',
+	'ore-zinc',
+	'raw-coal',
+	'ore-bioreserve',
+	'niobium',
+	'borax',
+	'oil-sand',
+	'molybdenum-ore',
+	-- Also turn off all the resources we programatically generate
+	'iron-rock',
+	'copper-rock',
+	'uranium-rock',
+	'zinc-rock',
+	'aluminium-rock',
+	'chromium-rock',
+	'coal-rock',
+	'lead-rock',
+	'nexelit-rock',
+	'nickel-rock',
+	'phosphate-rock-02',
+	'quartz-rock',
+	'salt-rock',
+	'tin-rock',
+	'titanium-rock',
+	'volcanic-pipe',
+	'regolites',
+	'rare-earth-bolide',
+	'phosphate-rock',
+	'sulfur-patch',
+	'oil-mk01',
+	'oil-mk02',
+	'oil-mk03',
+	'oil-mk04',
+	'tar-patch'
+}
+
+for _, ore in ipairs(ores) do
+	data.raw.resource[ore].autoplace = nil
+	data.raw['autoplace-control'][ore] = nil
+
+	for _, preset in pairs(data.raw['map-gen-presets']['default']) do
+		if preset and preset.basic_settings and preset.basic_settings.autoplace_controls and preset.basic_settings.autoplace_controls[ore] then
+		  preset.basic_settings.autoplace_controls[ore] = nil
+		end
+	end
+end

--- a/settings.lua
+++ b/settings.lua
@@ -1,0 +1,11 @@
+data:extend(
+{
+	{
+	type = "bool-setting",
+	name = "pyblock-ore-distance-richness",
+	setting_type = "startup",
+	default_value = false,
+	order = "e",
+	},
+}
+)


### PR DESCRIPTION
Update the map generation logic to naturally spawn islands, and place generated resources on those islands. 

Remove all resource spawning settings from map creation GUI since they don't do anything.

Added mod settings option to set distance based resource richness, defaulted to false to match King's design intention.

I also did a little bit of code organization and commenting to help others figure out what the intention of certain blocks is. 

![image](https://user-images.githubusercontent.com/4483110/89733455-3bc59c80-da1b-11ea-99d6-5f4c55093a08.png)
