### PR TITLE
removed techmultiplier cost from seaweed-mk01

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,9 @@
 ---------------------------------------------------------------------------------------------------
+Version: 2.0.4
+Date: 2024-4-17
+  Changes:
+    - Made sure very early techs are not effected by tech cost multiplier in line with Py Post Processing changes.
+---------------------------------------------------------------------------------------------------
 Version: 2.0.3
 Date: 2023-9-15
   Changes:

--- a/data-updates.lua
+++ b/data-updates.lua
@@ -158,6 +158,15 @@ RECIPE {
 }
 ]]--
 
+-- make sure very early techs are not effected by the tech cost multiplier
+local function prevent_cost_multiplier(name)
+    local tech = data.raw.technology[name]
+    if not tech then return end
+    tech.ignore_tech_cost_multiplier = true
+end
+
+prevent_cost_multiplier('seaweed-mk01')
+
 if register_cache_file ~= nil then
     register_cache_file({'pycoalprocessing', 'pyfusionenergy', 'pyindustry', 'pyrawores', 'pypetroleumhandling', 'pyalienlife', 'pyhightech', 'pyalternativeenergy', 'PyBlock'}, "__PyBlock__/cached-configs/PyBlock+pyalienlife+pyalternativeenergy+pycoalprocessing+pyfusionenergy+pyhightech+pyindustry+pypetroleumhandling+pyrawores")
 end


### PR DESCRIPTION
The version 0.2.22 of Pyanodons Post Processing removed tech multiplier costs from techs required to automate the first science pack, to avoid handcrafting large amounts of science with very high tech multipliers. In PyBlock seaweed is a pre-req for automating the first science pack and this PR applies the same tech multiplier removal.

Original PyPostProcessing issue: https://github.com/pyanodon/pybugreports/issues/467