### PR TITLE
mod setting fixes

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,10 @@
 ---------------------------------------------------------------------------------------------------
+Version: 3.2.6
+Date: ????
+  Bugfixes:
+    - Fixed disabling fun entity names mod setting not applying to atomizer and solid separator
+    - Fixed disabling fun entity names mod setting breaking when using non-english locale
+---------------------------------------------------------------------------------------------------
 Version: 3.2.5
 Date: 2025-06-08
   Locale:

--- a/data-updates.lua
+++ b/data-updates.lua
@@ -298,11 +298,12 @@ if settings.startup["disable-pyblock-fun-names"].value then
     "slaughterhouse-mk00",
     "soil-extractor-mk00",
     "washer-mk00",
-    "wpu-mk00"
+    "wpu-mk00",
+    "solid-separator-mk00"
   }) do
-    data.raw["assembling-machine"][entity].localised_name = { "entity-name-alt." .. entity }
+    data.raw["assembling-machine"][entity].localised_name = { "", "entity-name-alt." .. entity, "entity-name." .. entity }
   end
-  data.raw["furnace"]["compost-plant-mk00"].localised_name = { "entity-name-alt.compost-plant-mk00" }
+  data.raw["furnace"]["compost-plant-mk00"].localised_name = { "", "entity-name-alt.compost-plant-mk00", "entity-name-alt.compost-plant-mk00" }
 end
 
 if register_cache_file ~= nil then

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
 	"name": "PyBlock",
-	"version": "3.2.5",
+	"version": "3.2.6",
 	"factorio_version": "2.0",
 	"title": "PyBlock",
 	"author": "KingArthur",

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -53,14 +53,13 @@ shunt-inserter=Shunt Inserter
 
 [entity-name-alt]
 # just the normal names for these things
-driftwood=Driftwood
 ddc-mk00=Destructive Distilation Column MK 00
 soil-extractor-mk00=Soil Extractor MK 00
 solid-separator-mk00=Solid Separator MK 00
 burner-quenching-tower=Steampowered Quenching Tower
 washer-mk00=Washer MK 00
 wpu-mk00=Wood Processing Unit MK 00
-atomizer-mk00=Automizer MK 00
+atomizer-mk00=Atomizer MK 00
 automated-screener-mk00=Automated Screener MK 00
 slaughterhouse-mk00=Slaughterhouse MK 00
 fwf-mk00=Fastwood Forestry MK 00


### PR DESCRIPTION
Fixed disabling fun entity names mod setting not applying to atomizer and solid separator
Fixed disabling fun entity names mod setting breaking when using non-english locale